### PR TITLE
Fixed skip being ignored

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -484,8 +484,8 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
     });
 
     // LIMIT
-    if (filter.limit){
-        var offset = (filter.offset || 0), limit = filter.limit;
+    if (filter.limit || filter.skip) {
+        var offset = (filter.skip || 0), limit = (filter.limit || -1);
         sortCmd.push("LIMIT", offset, limit);
     }
 


### PR DESCRIPTION
Fixed a typo for skip.
Made it possible to use skip without limit and vice-versa.
