### PR TITLE
Fixing [model].all not consistently returning includes

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -461,7 +461,8 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
             innerSetUsed = true;
             if (indexes.length > 1) {
                 indexes.unshift(dest);
-                trans.sinterstore(indexes);
+                // trans.sinterstore(indexes);
+                trans.sunionstore(indexes);
             } else {
                 dest = indexes[0];
             }


### PR DESCRIPTION
When returning all objects and specifying includes, the included
relationship would be empty if some models had no references to the
included target - this was due to using `sinterstore` instead of
`sunionstore`
