### PR TITLE
Update redis.js

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -13,9 +13,9 @@ exports.initialize = function initializeSchema(schema, callback) {
         schema.settings.host = redisUrl.hostname;
         schema.settings.port = redisUrl.port;
 
-        if (redisAuth.length == 2) {
+        if (redisAuth.length > 1) {
             schema.settings.db = redisAuth[0];
-            schema.settings.password = redisAuth[1];
+            schema.settings.password = redisAuth.slice(1).join(':');
         }
     }
 


### PR DESCRIPTION
Split only first occurrence of ":"
It's fix for IrisRedis service of IrisCouch
They using passwords like "host:password"
